### PR TITLE
added updateSize() method to map

### DIFF
--- a/src/geom/line-string.js
+++ b/src/geom/line-string.js
@@ -20,6 +20,10 @@ export default class LineString extends OLComponent {
   componentWillReceiveProps(newProps) {
     this.updateFromProps(newProps);
   }
+
+  componentWillUnmount() {
+    this.context.feature.setGeometry(undefined);
+  }
 }
 
 LineString.propTypes = {

--- a/src/geom/polygon.js
+++ b/src/geom/polygon.js
@@ -21,8 +21,8 @@ export default class Polygon extends OLComponent {
     this.updateFromProps(newProps);
   }
 
-  render() {
-    return false;
+  componentWillUnmount() {
+    this.context.feature.setGeometry(undefined);
   }
 }
 

--- a/src/map.js
+++ b/src/map.js
@@ -32,6 +32,12 @@ export default class Map extends React.Component {
     this.map.setTarget(undefined)
   }
 
+  focus () {
+    const viewport = this.map.getViewport()
+    viewport.tabIndex = 0
+    viewport.focus()
+  }
+
   getChildContext () {
     return {
       map: this.map
@@ -51,10 +57,8 @@ export default class Map extends React.Component {
     )
   }
 
-  focus () {
-    const viewport = this.map.getViewport()
-    viewport.tabIndex = 0
-    viewport.focus()
+  updateSize () {
+    this.map.updateSize()
   }
 }
 


### PR DESCRIPTION
This PR exposes the `updateSize()` method of the OpenLayers map component in the interface of the corresponding React component.